### PR TITLE
Proper package read

### DIFF
--- a/packagereadmanager.cpp
+++ b/packagereadmanager.cpp
@@ -1,0 +1,98 @@
+#include "packagereadmanager.h"
+
+#include <QTcpSocket>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QDebug>
+#include <stdint.h>
+
+
+void PackageReadManager::addSocket(QTcpSocket* socket)
+{
+    Q_ASSERT(socket != nullptr);
+    connect(socket, SIGNAL(readyRead()), this, SLOT(onReadyRead()));
+    sockets_states.insert(socket, ReadState(socket));
+}
+
+void PackageReadManager::removeSocket(QTcpSocket* socket)
+{
+    Q_ASSERT(socket != nullptr);
+    disconnect(socket, SIGNAL(readyRead()), this, SLOT(onReadyRead()));
+    sockets_states.remove(socket);
+}
+
+void PackageReadManager::onReadyRead()
+{
+    ReadState& state = sockets_states[dynamic_cast<QTcpSocket*>(sender())];
+    Q_ASSERT(state.socket != nullptr);
+
+    switch (state.status) {
+    case nothing_read:
+        handleNothingRead(state);
+        break;
+    case header_size_read:
+        handleHeaderSizeRead(state);
+        break;
+    case header_read:
+        handleHeaderRead(state);
+        break;
+    default:
+        Q_ASSERT(false);
+    }
+
+    while (state.status == argument_read) {
+        emit packageReceived(state.socket, state.header, state.argument);
+        state.status = nothing_read;
+        handleNothingRead(state);
+    }
+}
+
+void PackageReadManager::handleNothingRead(ReadState& state)
+{
+    Q_ASSERT(state.status == nothing_read);
+
+    if (state.socket->bytesAvailable() >=
+        static_cast<qint64>(sizeof(state.header_size))) {
+
+        state.socket->read(reinterpret_cast<char*>(&state.header_size),
+                           sizeof(state.header_size));
+        Q_ASSERT(state.header_size > 0);
+
+        state.status = header_size_read;
+        handleHeaderSizeRead(state);
+    }
+}
+
+void PackageReadManager::handleHeaderSizeRead(ReadState& state)
+{
+    Q_ASSERT(state.status == header_size_read);
+
+    if (state.socket->bytesAvailable() >=
+        static_cast<qint64>(state.header_size)) {
+
+        QByteArray header_raw = state.socket->read(state.header_size);
+        Q_ASSERT(static_cast<uint64_t>(header_raw.size()) == state.header_size);
+        qDebug() << "Data received from server:";
+        qDebug().noquote() << QString::fromUtf8(header_raw);
+
+        state.header = QJsonDocument::fromJson(header_raw).object();
+        state.arg_size = state.header.value("argument_size").toInt();
+        Q_ASSERT(state.arg_size > 0);
+
+        state.status = header_read;
+        handleHeaderRead(state);
+    }
+}
+
+void PackageReadManager::handleHeaderRead(ReadState& state)
+{
+    Q_ASSERT(state.status == header_read);
+
+    if (state.socket->bytesAvailable() >= state.arg_size) {
+        state.argument = state.socket->read(state.arg_size);
+        Q_ASSERT(state.argument.size() == state.arg_size);
+        qDebug().noquote().nospace() << QString::fromUtf8(state.argument);
+
+        state.status = argument_read;
+    }
+}

--- a/packagereadmanager.cpp
+++ b/packagereadmanager.cpp
@@ -67,13 +67,12 @@ void PackageReadManager::handleHeaderSizeRead(ReadState& state)
 {
     Q_ASSERT(state.status == header_size_read);
 
+    size_t test = state.socket->bytesAvailable();
     if (state.socket->bytesAvailable() >=
         static_cast<qint64>(state.header_size)) {
 
         QByteArray header_raw = state.socket->read(state.header_size);
         Q_ASSERT(static_cast<uint64_t>(header_raw.size()) == state.header_size);
-        qDebug() << "Data received from server:";
-        qDebug().noquote() << QString::fromUtf8(header_raw);
 
         state.header = QJsonDocument::fromJson(header_raw).object();
         state.arg_size = state.header.value("argument_size").toInt();
@@ -91,7 +90,6 @@ void PackageReadManager::handleHeaderRead(ReadState& state)
     if (state.socket->bytesAvailable() >= state.arg_size) {
         state.argument = state.socket->read(state.arg_size);
         Q_ASSERT(state.argument.size() == state.arg_size);
-        qDebug().noquote().nospace() << QString::fromUtf8(state.argument);
 
         state.status = argument_read;
     }

--- a/packagereadmanager.h
+++ b/packagereadmanager.h
@@ -1,0 +1,55 @@
+#ifndef COMMUNICATIONMANAGER_H
+#define COMMUNICATIONMANAGER_H
+
+#include <QObject>
+#include <QJsonObject>
+#include <QTcpSocket>
+#include <QMap>
+#include <stdint.h>
+
+
+class PackageReadManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    void addSocket(QTcpSocket* socket);
+    void removeSocket(QTcpSocket* socket);
+
+signals:
+    void packageReceived(QTcpSocket* socket, const QJsonObject& header,
+                         const QByteArray& argument);
+
+private slots:
+    void onReadyRead();
+
+private:
+    enum ReadStatus {
+        nothing_read,
+        header_size_read,
+        header_read,
+        argument_read
+    };
+
+    struct ReadState {
+        ReadState() = default;
+        ReadState(QTcpSocket* socket) : socket(socket) {}
+
+        QTcpSocket* socket = nullptr;
+        ReadStatus status = nothing_read;
+
+        uint64_t header_size = 0;
+        QJsonObject header;
+
+        int arg_size = 0;
+        QByteArray argument;
+    };
+
+    void handleNothingRead(ReadState& state);
+    void handleHeaderSizeRead(ReadState& state);
+    void handleHeaderRead(ReadState& state);
+
+    QMap<QTcpSocket*, ReadState> sockets_states;
+};
+
+#endif // COMMUNICATIONMANAGER_H

--- a/server.cpp
+++ b/server.cpp
@@ -7,6 +7,8 @@
 Server::Server()
 {
     connect(this, &QTcpServer::newConnection, this, &Server::slotNewConnection);
+    connect(&read_manager, &PackageReadManager::packageReceived,
+            this, &Server::slotPackageReceived);
 }
 //_____________________________________________________________________________
 
@@ -173,8 +175,6 @@ void Server::slotNewConnection()
     QTcpSocket *socket = this->nextPendingConnection();
     connect(socket, &QTcpSocket::disconnected, this, &Server::slotDisconnected);
     read_manager.addSocket(socket);
-    connect(&read_manager, &PackageReadManager::packageReceived,
-            this, &Server::slotPackageReceived);
 
     clients.push_back(QSharedPointer<Client>(new Client(socket)));
     auto client = clients.back();

--- a/server.h
+++ b/server.h
@@ -5,6 +5,7 @@
 #include <QHostAddress>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QByteArray>
 #include <QList>
 #include <QMap>
 #include <QSharedPointer>
@@ -17,6 +18,7 @@
 #include "layer.h"
 #include "serializers.h"
 #include "serializable_types.h"
+#include "packagereadmanager.h"
 
 
 //=============================================================================
@@ -40,7 +42,8 @@ public:
 
 public slots:
     void slotNewConnection(); // New pending connection
-    void slotReadyRead();     // Client socket ready to read
+    void slotPackageReceived(QTcpSocket* socket, const QJsonObject& header,
+                             const QByteArray& argument);
     void slotDisconnected();  // Client disconnected
 
 private:
@@ -53,6 +56,7 @@ private:
     QList<QSharedPointer<Client>> clients;
     QList<QSharedPointer<Layer>> scene;
     Client::id_type curr_sender_id;
+    PackageReadManager read_manager;
 };
 //=============================================================================
 

--- a/server.pro
+++ b/server.pro
@@ -15,6 +15,7 @@ SOURCES += main.cpp \
     client_api.cpp \
     graphics_items.cpp \
     layer.cpp \
+    packagereadmanager.cpp \
     serializable_types.cpp \
     serializers.cpp \
     server.cpp
@@ -35,6 +36,7 @@ HEADERS += \
     cyclic_stack.h \
     graphics_items.h \
     layer.h \
+    packagereadmanager.h \
     serializable_types.h \
     serializers.h \
     server.h


### PR DESCRIPTION
This feature solved the problem that was caused by splitting single package into multiple packets in tcp/ip. Now you can use the program with smaller socket buffer sizes and you can have great experience not only on localhost.